### PR TITLE
Add time-locale-compat dependency to test suite target

### DIFF
--- a/rotating-log.cabal
+++ b/rotating-log.cabal
@@ -42,6 +42,7 @@ test-suite test-rotate
     base,
     bytestring,
     time,
+    time-locale-compat,
     filepath,
     directory
 


### PR DESCRIPTION
Problem: `stack test` fails, complaining that the `Data.Time.Locale.Compat` module cannot be found.

```
/Users/danburton/github.com/Soostone/rotating-log/src/System/RotatingLog.hs:35:18:
    Could not find module ‘Data.Time.Locale.Compat’
    It is a member of the hidden package ‘time-locale-compat-0.1.1.1@timel_Ciz7M1U3da73rRwCjRF3Np’.
    Perhaps you need to add ‘time-locale-compat’ to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
```

Solution: take the suggestion and add `time-locale-compat` to the test suite dependencies.