### PR TITLE
update dependencies + remove a compilation warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 TAGS
 *DS_*
 *.log
+.stack-work

--- a/rotating-log.cabal
+++ b/rotating-log.cabal
@@ -1,5 +1,5 @@
 name:                rotating-log
-version:             0.4.2
+version:             0.4.3
 description:         Size-limited, concurrent, automatically-rotating log writer.
 Synopsis:            Size-limited, concurrent, automatically-rotating log writer.
 license:             BSD3
@@ -25,7 +25,7 @@ library
   build-depends:
     base               >= 4    && < 5,
     bytestring         >= 0.8,
-    time               >= 1.5 && < 1.7,
+    time               >= 1.5 && < 1.9,
     old-locale         >= 1.0,
     time-locale-compat,
     filepath           >= 1.0,
@@ -38,6 +38,8 @@ test-suite test-rotate
   main-is: TestRotate.hs
   ghc-options: -Wall
   hs-source-dirs: test, src
+  other-modules:
+    System.RotatingLog
   build-depends:
     base,
     bytestring,

--- a/src/System/RotatingLog.hs
+++ b/src/System/RotatingLog.hs
@@ -92,6 +92,7 @@ mkRotatingLog pre limit buf pa = do
 
 
 -------------------------------------------------------------------------------
+openLogFile :: RotatingLog -> IO Handle
 openLogFile RotatingLog{..} = do
     let fp = curLogFileName namePrefix
     h <- openFile fp AppendMode

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration/
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.5
+resolver: lts-10.3
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
Trying to build a project and upgrading to LTS 10.3 the time lib was upgraded to `1.8.0.2`.

The test suite appear to work.

I also removed a warning during compilation.